### PR TITLE
be informed about criteria or guidelines for lottery selection process

### DIFF
--- a/code/duckduckGoose/app/src/main/java/com/example/duckduckgoose/EventDetailActivity.java
+++ b/code/duckduckGoose/app/src/main/java/com/example/duckduckgoose/EventDetailActivity.java
@@ -110,6 +110,7 @@ public class EventDetailActivity extends AppCompatActivity {
                 : pickStateFromTitle(title);
         
         // if this user is an entrant (not an organizer), show lottery-info popup before they register
+        // TODO -- also might wanna consider adding a check here for administrators with like "isAdministratorMode" to get this confirmed (as admins need not see terms and conditions type stuff yk)
         if (!isOrganizerMode) {
             try {
                 new AlertDialog.Builder(this)


### PR DESCRIPTION
I have added the pop up alert dialog for when an entrant clicks on an event card.

TODO -- This will need to actually have the correct terms and conditions when we actually implement the lottery.